### PR TITLE
dep: add Go modules support to Dependabot with groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,25 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: ⬆
+
+  # Go modules
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: ⬆
+    groups:
+      # Group all patch and minor updates together
+      non-breaking:
+        update-types:
+          - "minor"
+          - "patch"
+
+      # Group CLI framework dependencies
+      cli-framework:
+        patterns:
+          - "github.com/spf13/cobra"
+          - "github.com/spf13/pflag"


### PR DESCRIPTION
Configure Dependabot to manage Go module dependencies with intelligent grouping to reduce PR noise:

- Add gomod ecosystem with weekly Monday schedule
- Group non-breaking updates (minor/patch) into single PR
- Group CLI framework dependencies (cobra + pflag) together
- Keep major updates separate for careful review
- Limit to 10 open PRs maximum
